### PR TITLE
Fix bug: close socket when connect failed

### DIFF
--- a/corelib/net/socket.c
+++ b/corelib/net/socket.c
@@ -405,11 +405,10 @@ static void connected_sock(ph_socket_t s, const ph_sockaddr_t *addr,
     if (!sock) {
       status = ENOMEM;
     }
-  } else {
-    //close socket when connect failed
-    if (s > 0) {
-      close(s);
-    }
+  }
+
+  if (status != 0 && rac->s != -1) {
+    close(rac->s);
   }
 
   calc_elapsed(rac);


### PR DESCRIPTION
We should close the Socket when connect failed, i didnot find it close the socket in the Function: attempt_connect.
Is there other code to close the bad socket?
