### PR TITLE
'Slot' should be put before the compare expression to guarantee thread safe.

### DIFF
--- a/corelib/counter.c
+++ b/corelib/counter.c
@@ -470,12 +470,10 @@ uint8_t ph_counter_scope_register_counter(
 {
   uint8_t slot;
 
-  do {
-    slot = scope->next_slot;
-    if (scope->next_slot >= scope->num_slots) {
-      return PH_COUNTER_INVALID;
-    }
-  } while (!ck_pr_cas_8(&scope->next_slot, slot, slot + 1));
+  slot = ck_pr_faa_8(&scope->next_slot, 1);
+  if (slot >= scope->num_slots) {
+    return PH_COUNTER_INVALID;
+  }
 
   /* we've claimed slot; copy the name in */
   scope->slot_names[slot] = strdup(name);
@@ -489,18 +487,15 @@ bool ph_counter_scope_register_counter_block(
     const char **names)
 {
   int i;
-  uint8_t slot;
 
   if (scope->next_slot != first_slot) {
     return false;
   }
 
-  do {
-    slot = scope->next_slot;
-    if (scope->next_slot + num_slots > scope->num_slots) {
-      return PH_COUNTER_INVALID;
-    }
-  } while (!ck_pr_cas_8(&scope->next_slot, slot, slot + num_slots));
+  ck_pr_add_8(&scope->next_slot, num_slots);
+  if (scope->next_slot > scope->num_slots) {
+      return false;
+  }
 
   for (i = 0; i < num_slots; i++) {
     scope->slot_names[first_slot + i] = strdup(names[i]);

--- a/corelib/memory.c
+++ b/corelib/memory.c
@@ -132,7 +132,8 @@ ph_memtype_t ph_memtype_register(const ph_memtype_def_t *def)
 
   mt = ck_pr_faa_int(&next_memtype, 1);
   if ((uint32_t)mt >= memtypes_size) {
-    ph_panic("You need to recompile libphenom with memtypes_size = %d", 2 * memtypes_size);
+    ph_panic("You need to recompile libphenom with memtypes_size = %d", 2 *
+        memtypes_size);
   }
   mem_type = &memtypes[mt];
   memset(mem_type, 0, sizeof(*mem_type));
@@ -185,7 +186,8 @@ ph_memtype_t ph_memtype_register_block(
 
   mt = ck_pr_faa_int(&next_memtype, num_types);
   if ((uint32_t)mt >= memtypes_size) {
-    ph_panic("You need to recompile libphenom with memtypes_size = %d", 2 * memtypes_size);
+    ph_panic("You need to recompile libphenom with memtypes_size = %d", 2 *
+        memtypes_size);
   }
 
   for (i = 0; i < num_types; i++) {


### PR DESCRIPTION
To guarantee thread safe, slot assignment should be put before compare expression.

Otherwise, it may cause overflow.
