### PR TITLE
Make _XOPEN_SOURCE definition agree with _POSIX_C_SOURCE for POSIX 2008 env

### DIFF
--- a/include/phenom/defs.h
+++ b/include/phenom/defs.h
@@ -33,9 +33,14 @@
 # define _REENTRANT
 #endif
 #define __EXTENSIONS__ 1
-#define _XOPEN_SOURCE 600
 #define _BSD_SOURCE
+#ifdef __sun__
+#define _XOPEN_SOURCE 600
+#define _POSIX_C_SOURCE 200112L
+#else
+#define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 200809
+#endif
 #define _GNU_SOURCE
 #define _DARWIN_C_SOURCE
 


### PR DESCRIPTION
If we want a POSIX 2008 environment as requested by _POSIX_C_SOURCE here, _XOPEN_SOURCE should be 700 so they are in agreement.

See:
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap02.html#tag_02_01_04

Fixes build on FreeBSD 10 which redefines _POSIX_C_SOURCE depending on _XOPEN_SOURCE def.
