### PR TITLE
Correctly set EVFILT_WRITE for nbio emitters when using kqueue.

### DIFF
--- a/corelib/nbio/kqueue.c
+++ b/corelib/nbio/kqueue.c
@@ -185,7 +185,7 @@ ph_result_t ph_nbio_emitter_apply_io_mask(struct ph_nbio_emitter *emitter,
     nev++;
   }
   if (mask & PH_IOMASK_WRITE) {
-    EV_SET(&kev[nev], job->fd, EVFILT_READ, EV_ADD|EV_ONESHOT, 0, 0, job);
+    EV_SET(&kev[nev], job->fd, EVFILT_WRITE, EV_ADD|EV_ONESHOT, 0, 0, job);
     nev++;
   }
   if ((mask & (PH_IOMASK_READ|PH_IOMASK_WRITE)) == 0) {


### PR DESCRIPTION
Summary: Fixes a typo in corelib/nbio/kqueue.c:ph_nbio_emitter_apply_io_mask
that incorrectly set EVFILT_READ when the mask parameter specified interest in
write events.
