### PR TITLE
Cleanup leftover ph_stm_init() prototype.

### DIFF
--- a/corelib/streams/make.c
+++ b/corelib/streams/make.c
@@ -103,16 +103,16 @@ static void stm_init(void)
 
   mt_stm = ph_memtype_register(&stm_def);
   if (mt_stm == PH_MEMTYPE_INVALID) {
-    ph_panic("ph_stm_init: unable to register memory types");
+    ph_panic("stm_init: unable to register memory types");
   }
 
   err = pthread_mutexattr_init(&mtx_attr);
   if (err) {
-    ph_panic("ph_stm_init: mutexattr_init: `Pe%d", err);
+    ph_panic("stm_init: mutexattr_init: `Pe%d", err);
   }
   err = pthread_mutexattr_settype(&mtx_attr, PTHREAD_MUTEX_ERRORCHECK);
   if (err) {
-    ph_panic("ph_stm_init: mutexattr ERRORCHECK: `Pe%d", err);
+    ph_panic("stm_init: mutexattr ERRORCHECK: `Pe%d", err);
   }
 }
 PH_LIBRARY_INIT_PRI(stm_init, 0, 7)

--- a/include/phenom/stream.h
+++ b/include/phenom/stream.h
@@ -261,9 +261,6 @@ ph_stream_t *ph_stm_make(const struct ph_stream_funcs *funcs,
  */
 void ph_stm_destroy(ph_stream_t *stm);
 
-/** initialize the stream layer */
-ph_result_t ph_stm_init(void);
-
 /* functions that operate on a file descriptor */
 extern struct ph_stream_funcs ph_stm_funcs_fd;
 


### PR DESCRIPTION
The method was removed in commit 07b55a27.

fixes issue #77.