### PR TITLE
Static assert fix

### DIFF
--- a/include/phenom/defs.h
+++ b/include/phenom/defs.h
@@ -374,7 +374,7 @@ void ph_static_assert(bool constexpr, identifier_message);
      typedef struct { \
        int ph_defs_paste1(static_assertion_failed_, msg) : \
        !!(expr); \
-     } ph_defs_gen_symbol(static_assertion_failed_)
+     } ph_defs_gen_symbol(static_assertion_failed_) CK_CC_UNUSED
 # endif
 
 /** Log a PH_LOG_PANIC level message, then abort()

--- a/tests/buf.c
+++ b/tests/buf.c
@@ -17,6 +17,7 @@
 #include "phenom/sysutil.h"
 #include "phenom/string.h"
 #include "phenom/buffer.h"
+#include "phenom/printf.h"
 #include "tap.h"
 
 static void test_straddle_edges(void)


### PR DESCRIPTION
Latest-ish clang on MacOS detects the static assert struct as an unused type which causes a warning that results in a build failure. I tested that the assertions will still fail with the type marked unused, just to be sure. It should probably be using the c11/_Static_assert(), but I'm not familiar enough with autotools to resolve that at the moment.

I also fixed a warning in tests/buf.c.