### PR TITLE
fix compile error with the latest libphenom and concurrencyKit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,10 +140,15 @@ esac
 
 # If you're bumping the CK max-version here, you must also bump it in
 # travis/deps.sh otherwise you will break the CI build
-if ! $PKG_CONFIG --exists --atleast-version=0.5.0 --max-version=0.5.1 --print-errors ck ; then
+if ! $PKG_CONFIG --exists --atleast-version=0.5.0 --max-version=0.6.0 --print-errors ck ; then
   AC_MSG_ERROR([ck is required])
 fi
-CFLAGS="$CFLAGS `$PKG_CONFIG --cflags ck`"
+
+CK_VERSION=`$PKG_CONFIG --modversion ck`
+CK_MAJOR=`echo $CK_VERSION | cut -d. -f1`
+CK_MINOR=`echo $CK_VERSION | cut -d. -f2`
+CK_MICRO=`echo $CK_VERSION | cut -d. -f3`
+CFLAGS="$CFLAGS `$PKG_CONFIG --cflags ck` -DCK_RELEASE_VERSION=`expr \( $CK_MAJOR \* 1000 \) \+ \( $CK_MINOR \* 100 \) + \( $CK_MICRO \* 10 \)`"
 LIBS="$LIBS `pkg_config_libs ck`"
 
 AC_PATH_PROG(PHP, php, true)

--- a/corelib/thread.c
+++ b/corelib/thread.c
@@ -116,7 +116,12 @@ static ph_thread_t *ph_thread_init_myself(bool booting)
   ph_thread_t *me;
   ck_epoch_record_t *er;
 
+#if CK_RELEASE_VERSION >= 600
+  er = ck_epoch_recycle(&misc_epoch, NULL);
+#else
   er = ck_epoch_recycle(&misc_epoch);
+#endif
+
   if (er) {
     me = ph_container_of(er, ph_thread_t, epoch_record);
   } else {
@@ -124,7 +129,13 @@ static ph_thread_t *ph_thread_init_myself(bool booting)
     if (!me) {
       ph_panic("fatal OOM in ph_thread_init_myself()");
     }
+
+#if CK_RELEASE_VERSION >= 600
+    ck_epoch_register(&misc_epoch, &me->epoch_record, NULL);
+#else
     ck_epoch_register(&misc_epoch, &me->epoch_record);
+#endif
+
     ck_stack_push_mpmc(&ph_thread_all_threads, &me->thread_linkage);
     ph_counter_init_thread(me);
   }

--- a/include/phenom/counter.h
+++ b/include/phenom/counter.h
@@ -382,6 +382,9 @@ uint8_t ph_counter_scope_get_num_slots(
 struct ph_counter_scope_iterator {
   void *ptr;
   intptr_t offset;
+  #if CK_RELEASE_VERSION >= 600
+    void *map;
+  #endif
 };
 typedef struct ph_counter_scope_iterator ph_counter_scope_iterator_t;
 

--- a/travis/deps.sh
+++ b/travis/deps.sh
@@ -10,7 +10,7 @@ esac
 HERE=$PWD
 
 # There is no CK package available for ubuntu yet
-CK_VER=0.5.1
+CK_VER=0.6.0
 CK_RELEASE=https://github.com/concurrencykit/ck/archive/$CK_VER.tar.gz
 if test ! -f $CK_VER.tar.gz ; then
   wget $CK_RELEASE


### PR DESCRIPTION
This is an attempt to get things working with different CK versions precisely with CK version 0.6.0 and above.  ref:[compile error with the latest libphenom and concurrencyKit #84](https://github.com/facebook/libphenom/issues/84)